### PR TITLE
Fixed bug where task couldn't be opened right after creation

### DIFF
--- a/src/components/Stories.vue
+++ b/src/components/Stories.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="taskEditorSectionIdAndTask.task.gid">
+  <div v-if="taskEditorSectionIdAndTask?.task.gid">
     <div class="story">
       <span class="story-date">{{
         formatDate(taskEditorSectionIdAndTask.task.created_at)

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -15,7 +15,7 @@ import {
 } from "@/types/asana";
 import { Move, Swimlane } from "@/types/layout";
 import { convertColorToHexes, getColumnCount } from "@/utils/asana-specific";
-import { asanaClient } from "../auth";
+import { asanaClient, useAuthStore } from "../auth";
 
 
 export const useAsanaStore = defineStore("asana", {
@@ -210,8 +210,9 @@ export const useAsanaStore = defineStore("asana", {
                 section: taskAndSectionId.sectionId,
                 project: this.selectedProject,
               }],
-          } as any);
-        this.tasks.push(task as Task);
+          } as any) as Task;
+        task.created_by = { name: useAuthStore().user?.name ?? "" };
+        this.tasks.push(task);
         this.UPDATE_CUSTOM_FIELDS(task.gid);
       }
 

--- a/src/types/asana.ts
+++ b/src/types/asana.ts
@@ -28,7 +28,7 @@ export type User = asana.resources.Users.Type & {
 };
 export type Stories = asana.resources.Stories.Type;
 export type Task = Omit<asana.resources.Tasks.Type, "tags"> & {
-  created_by: Resource,
+  created_by: { name: string },
   html_notes: string | undefined,
   stories: Stories[],
   tags: TaskTag[],


### PR DESCRIPTION
The api response for task creation didn't include the `created_by` field, but this field was required by the task editor view, so I had to set the field manually.