### PR TITLE
Fix task drag delay

### DIFF
--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -157,10 +157,9 @@ export default defineComponent({
     };
 
     const onDrop = (event, endSectionId: string) => {
-      asanaStore.reloadLock = {
-        locked: false,
-        lastLocked: new Date()
-      }
+      asanaStore.reloadState.locked = false;
+      asanaStore.reloadState.lastLocked = new Date();
+
       const startSectionId = event.dataTransfer.getData("startSectionId");
       const taskId = event.dataTransfer.getData("taskId");
       let el = event.target;
@@ -186,7 +185,7 @@ export default defineComponent({
     };
 
     const onDragStart = () => {
-      asanaStore.reloadLock.locked = true;
+      asanaStore.reloadState.locked = true;
     }
 
     const onDragEnd = () => {

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -33,6 +33,7 @@
       v-if="!columnCollapsed(section?.gid ?? '')"
       @drop="onDrop($event, section?.gid ?? '')"
       @dragenter="onDragEnter($event)"
+      @dragstart="onDragStart()"
       @dragend="onDragEnd()"
       @dragover.prevent
       class="droppable"
@@ -156,6 +157,10 @@ export default defineComponent({
     };
 
     const onDrop = (event, endSectionId: string) => {
+      asanaStore.reloadLock = {
+        locked: false,
+        lastLocked: new Date()
+      }
       const startSectionId = event.dataTransfer.getData("startSectionId");
       const taskId = event.dataTransfer.getData("taskId");
       let el = event.target;
@@ -171,6 +176,7 @@ export default defineComponent({
         endSectionId: endSectionId,
         taskId: taskId,
         siblingTaskId: siblingTaskId,
+        endOfColumn: el === null
       });
     };
 
@@ -178,6 +184,10 @@ export default defineComponent({
       removeDragOverClass();
       event.currentTarget.classList.add("drag-over");
     };
+
+    const onDragStart = () => {
+      asanaStore.reloadLock.locked = true;
+    }
 
     const onDragEnd = () => {
       removeDragOverClass();
@@ -198,6 +208,7 @@ export default defineComponent({
       toggleColumn,
       onDrop,
       onDragEnter,
+      onDragStart,
       onDragEnd,
     };
   },

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -30,6 +30,7 @@ export const useAsanaStore = defineStore("asana", {
     tags: jsonstore.get("tags", []) as TaskTag[],
     users: jsonstore.get("users", []) as User[],
     allTags: jsonstore.get("allTags", []) as TaskTag[],
+    lastUpdatedTime: null
   }),
   getters: {
     IS_SECTION_COMPLETE: (state) => (columnName: string) => {
@@ -455,7 +456,7 @@ export const useAsanaStore = defineStore("asana", {
     },
 
     LOAD_AND_MERGE_TASKS(): void {
-      loadTasks(this.MERGE_TASKS, lastUpdatedTime);
+      loadTasks(this.MERGE_TASKS, this.lastUpdatedTime);
     },
 
     async LOAD_QUERIED_TASK(query: string): Promise<Resource[] | undefined> {
@@ -476,7 +477,6 @@ export const useAsanaStore = defineStore("asana", {
   }
 });
 
-let lastUpdatedTime: string | null = null;
 async function loadTasks(action: (tasks: Task[]) => any, lastUpdated: string | null) {
   const asanaStore = useAsanaStore();
   if (asanaClient && asanaStore.selectedProject) {
@@ -514,7 +514,7 @@ async function loadTasks(action: (tasks: Task[]) => any, lastUpdated: string | n
     for (; taskResponse; taskResponse = await taskResponse.nextPage()) {
       action(taskResponse.data);
     }
-    lastUpdatedTime = new Date().toISOString();
+    asanaStore.lastUpdatedTime = new Date().toISOString();
   }
 }
 

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -404,10 +404,7 @@ export const useAsanaStore = defineStore("asana", {
     LOAD_TASKS(): void {
       this.ADD_ACTION(
         "loading tasks",
-        async () => {
-          await loadTasks(this.ADD_TASKS, null);
-          console.log("after loading: ", this.tasks.length);
-        }
+        async () => loadTasks(this.ADD_TASKS, null)
       );
     },
 
@@ -457,9 +454,8 @@ export const useAsanaStore = defineStore("asana", {
       this.ADD_ACTION("loading all tags", loadAllTags);
     },
 
-    async LOAD_AND_MERGE_TASKS() {
-      await loadTasks(this.MERGE_TASKS, lastUpdatedTime);
-      console.log("after reload: ", this.tasks.length);
+    LOAD_AND_MERGE_TASKS(): void {
+      loadTasks(this.MERGE_TASKS, lastUpdatedTime);
     },
 
     async LOAD_QUERIED_TASK(query: string): Promise<Resource[] | undefined> {

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -151,11 +151,12 @@ export const useAsanaStore = defineStore("asana", {
     },
 
     MERGE_TASKS(payload: Task[]): void {
-      // replace individual task with each task in payload
-      if (this.reloadLock.locked ||
-        (this.reloadLock.lastLocked &&
-          new Date().getTime() - this.reloadLock.lastLocked.getTime() < 5000)) return;
+      const reloadRecentlyLocked = this.reloadLock.lastLocked &&
+        (new Date().getTime() - this.reloadLock.lastLocked.getTime()) < 5000;
+        
+      if (this.reloadLock.locked || reloadRecentlyLocked) return;
 
+      // replace individual task with each task in payload
       payload.forEach(task => {
         const index = this.tasks.findIndex((t) => t.gid === task.gid);
         if (index !== -1) {

--- a/src/store/asana/state.ts
+++ b/src/store/asana/state.ts
@@ -30,4 +30,5 @@ export interface State {
   tags: TaskTag[],
   users: User[],
   allTags: TaskTag[],
+  lastUpdatedTime: string | null
 }

--- a/src/store/asana/state.ts
+++ b/src/store/asana/state.ts
@@ -19,6 +19,11 @@ export interface WorkerError {
   description: string,
 }
 
+export interface ReloadLock {
+  locked: boolean,
+  lastLocked: Date | null
+}
+
 export interface State {
   workspace: string | null,
   projects: Project[],
@@ -30,5 +35,6 @@ export interface State {
   tags: TaskTag[],
   users: User[],
   allTags: TaskTag[],
-  lastUpdatedTime: string | null
+  lastUpdatedTime: string | null,
+  reloadLock: ReloadLock
 }

--- a/src/store/asana/state.ts
+++ b/src/store/asana/state.ts
@@ -19,9 +19,10 @@ export interface WorkerError {
   description: string,
 }
 
-export interface ReloadLock {
+export interface ReloadState {
   locked: boolean,
-  lastLocked: Date | null
+  lastLocked: Date | null,
+  lastReloadStart: Date | null
 }
 
 export interface State {
@@ -36,5 +37,5 @@ export interface State {
   users: User[],
   allTags: TaskTag[],
   lastUpdatedTime: string | null,
-  reloadLock: ReloadLock
+  reloadState: ReloadState
 }

--- a/src/store/asana/worker.ts
+++ b/src/store/asana/worker.ts
@@ -75,7 +75,7 @@ async function reloadTasks() {
   const actions = asanaStore.actions;
 
   while (workersRunning) {
-    if (actions.length === 0 && !asanaStore.reloadLock.locked) {
+    if (actions.length === 0 && !asanaStore.reloadState.locked) {
       asanaStore.LOAD_AND_MERGE_TASKS();
     }
     await sleep(5000);

--- a/src/store/asana/worker.ts
+++ b/src/store/asana/worker.ts
@@ -75,7 +75,7 @@ async function reloadTasks() {
   const actions = asanaStore.actions;
 
   while (workersRunning) {
-    if (actions.length === 0) {
+    if (actions.length === 0 && !asanaStore.reloadLock.locked) {
       asanaStore.LOAD_AND_MERGE_TASKS();
     }
     await sleep(5000);

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -3,6 +3,7 @@ export interface Move {
   endSectionId: string;
   taskId: string;
   siblingTaskId: string;
+  endOfColumn: boolean;
 }
 
 export interface Swimlane {


### PR DESCRIPTION
Also changed the drag behaviour:

Before, the dragged task would insert itself after the task it gets dropped on, so you couldn't drag the task to the first position in one move. Now, the dragged task replaces the position of the task it gets dropped on.