### PR TITLE
Prettify task editor - added basic styling & switched input component

### DIFF
--- a/src/components/BasicInput.vue
+++ b/src/components/BasicInput.vue
@@ -1,0 +1,56 @@
+<template>
+  <n-space vertical>
+    <n-input 
+      ref="inputInstRef"
+      v-model:value="inputValue" 
+      type="text" 
+      placeholder=""
+      @update:value="updateInput"
+    />
+  </n-space>
+</template>
+
+<script lang="ts">
+
+import { defineComponent, ref, onMounted } from 'vue';
+import { NInput, NSpace, InputInst } from 'naive-ui';
+
+export default defineComponent({
+  components: { NInput, NSpace },
+  props: {
+    input: {
+      type: String,
+    }
+  },
+  setup (props, { emit }) {
+    const inputInstRef = ref<InputInst | null>(null);
+    const inputValue = ref<string>("");
+
+    const updateInput = (input: string) => {
+      emit("update:input", input);
+    };
+
+    const handleFocus = () => {
+      inputInstRef.value?.focus();
+    };
+
+    onMounted(() => {
+      handleFocus();
+
+      if (!props.input) {
+        inputValue.value = "";
+      } else {
+        inputValue.value = props.input;
+      }
+
+    });
+
+    return {
+      inputInstRef,
+      inputValue,
+      handleFocus,
+      updateInput,
+    }
+  }
+});
+</script>

--- a/src/components/TagSelector.vue
+++ b/src/components/TagSelector.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted, watch, PropType, h } from 'vue'
+import { defineComponent, ref, computed, onMounted, watch, PropType } from 'vue'
 import { NSelect, NSpace } from 'naive-ui';
 import { TagOption } from '@/types/vue';
 import { Task, TaskTag } from "@/types/asana";

--- a/src/components/TagSelector.vue
+++ b/src/components/TagSelector.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted, watch, PropType } from 'vue'
+import { defineComponent, ref, computed, onMounted, watch, PropType } from 'vue';
 import { NSelect, NSpace } from 'naive-ui';
 import { TagOption } from '@/types/vue';
 import { Task, TaskTag } from "@/types/asana";
@@ -57,7 +57,7 @@ export default defineComponent({
 // value prop of component only accepts an array of strings, so need array of tagIds
 function makeTagId(tags: TaskTag[] | undefined): string[] {
   const tagIds = tags?.map((tag) => {
-    return tag.gid
+    return tag.gid;
   });
   return tagIds ?? [];
 }

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -155,7 +155,9 @@ hr {
   margin-left: 4px;
   margin-bottom: 4px;
   background-color: white;
-  width: 16rem;
+  margin-right: 2px;
+  width: 48%; 
+  max-width: 15rem;
   min-height: 2.5rem;
   cursor: move;
   display: inline-block;
@@ -171,7 +173,7 @@ hr {
   margin-left: 0.1rem;
   display: inline-block;
   overflow-wrap: break-word;
-  width: 14rem;
+  width: 90%;
 }
 .tag {
   border-radius: 100%;

--- a/src/components/TaskEditor.vue
+++ b/src/components/TaskEditor.vue
@@ -22,17 +22,15 @@
           >open in asana</a
         >
         <label for="name">name</label>
-        <input
-          autocomplete="off"
-          id="name"
-          type="text"
-          v-model="taskEditorSectionIdAndTask.task.name"
-          @keydown.enter="save(taskEditorSectionIdAndTask)"
-        />
+        <BasicInput v-model:input="taskEditorSectionIdAndTask.task.name" @keydown.enter="save(taskEditorSectionIdAndTask)"></BasicInput>
       </div>
       <div class="assignee">
         <label for="assignee">assignee</label>
         <AssigneeSelector></AssigneeSelector>
+      </div>
+      <div class="due-date">
+        <label>due date</label>
+        <DateSelector v-model:date="dueDate"></DateSelector>
       </div>
       <div class="description">
         <label for="description">description</label>
@@ -41,15 +39,13 @@
           v-on:update="updateHtmlNotes($event, taskEditorSectionIdAndTask)"
         />
       </div>
-      <div class="due-date">
-        <label>due date</label>
-        <DateSelector v-model:date="dueDate"></DateSelector>
-      </div>
       <div class="tags">
         <label>tags</label>
         <TagSelector :task="taskEditorSectionIdAndTask.task"></TagSelector>
       </div>
-      <Stories></Stories>
+      <div class="stories">
+        <Stories></Stories>
+      </div>
       <div class="new-comment" v-if="taskEditorSectionIdAndTask.task.gid">
         <label for="new comment">new comment</label>
         <TextEditor
@@ -87,6 +83,7 @@
 <script lang="ts">
 import { defineComponent, ref, watch, computed } from "vue";
 import AssigneeSelector from "./AssigneeSelector.vue";
+import BasicInput from "./BasicInput.vue";
 import TextEditor from "./TextEditor.vue";
 import Stories from "./Stories.vue";
 import { TaskAndSectionId } from "@/types/asana";
@@ -97,8 +94,8 @@ import { parse } from "date-fns";
 import { useAsanaStore } from "@/store/asana";
 import { usePrefStore } from "@/store/preferences";
 
-export default defineComponent({
-  components: { AssigneeSelector, TextEditor, Stories, TagSelector, DateSelector },
+export default defineComponent({ 
+  components: { AssigneeSelector, TextEditor, Stories, TagSelector, DateSelector, BasicInput },
   setup() {
     const asanaStore = useAsanaStore();
     const prefStore = usePrefStore();
@@ -193,6 +190,14 @@ export default defineComponent({
 }
 label {
   display: block;
+  font-size: 0.85rem;
+  color: grey;
+  font-weight: 400;
+  margin-bottom: 0.35rem;
+  margin-top: 0.5rem;
+}
+.assignee {
+  text-align: center;
 }
 .due-date,
 
@@ -206,12 +211,11 @@ label {
 .new-comment {
   text-align: left;
 }
-
-label {
-  font-size: 0.5rem;
+.stories {
+  margin-top: 1rem;
 }
 .tiny-link {
-  font-size: 0.5rem;
+  font-size: 0.6rem;
 }
 .right {
   float: right;
@@ -223,12 +227,12 @@ textarea {
   box-sizing: border-box;
   width: 100%;
   border: 1px solid #999999;
-}
-textarea {
   min-height: 10rem;
 }
 
 .task-editor {
+  border-radius: 8px;
+  padding: 20px;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -243,6 +247,7 @@ textarea {
 }
 
 button.primary {
+  margin-top: 1rem;
   width: 10rem;
   background-color: #cccccc;
   border: none;
@@ -253,6 +258,7 @@ button.primary:hover {
 }
 
 button.secondary {
+  margin-top: 1rem;
   width: 10rem;
   float: right;
   background-color: #aaaaaa;

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -97,7 +97,7 @@ export default defineComponent({
 }
 .ProseMirror p {
   margin-top: 0.8rem;
-  height: 1.5rem;
+  min-height: 2rem;
   width: 100%;
 }
 ol li { 

--- a/src/utils/renderTag.ts
+++ b/src/utils/renderTag.ts
@@ -9,6 +9,7 @@ export const renderTag: SelectRenderTag = ({ option, handleClose }) => {
       closable: true,
       round: true,
       themeOverrides: { 
+        heightMedium: '24px',
         color: option.color as Color, 
         border: option.color as Color,
         textColor: option.font as Color, 


### PR DESCRIPTION
Before:
<img width="914" alt="Screen Shot 2022-04-07 at 4 38 41 PM" src="https://user-images.githubusercontent.com/90949170/162292222-b377d0b8-5728-4ba0-bc80-bf3fc218a0ae.png">

After first iteration:
<img width="920" alt="Screen Shot 2022-04-07 at 2 47 42 PM" src="https://user-images.githubusercontent.com/90949170/162291410-044a01a6-9fea-4538-b40f-8ff381eedfc1.png">
