### PR TITLE
First pass at display and edit of custom fields

### DIFF
--- a/src/components/CustomEnumFieldSelector.vue
+++ b/src/components/CustomEnumFieldSelector.vue
@@ -1,0 +1,65 @@
+<template>
+  <n-space vertical>
+    <!-- Minor note: we don't put clearable because the Asana API doesn't properly allow removing values -->
+    <n-select v-model:value="selectedEnumGid" filterable placeholder="" :render-tag="renderTag" :options="options" />
+  </n-space>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch, PropType } from 'vue';
+import { NSelect, NSpace } from 'naive-ui';
+import { TagOption } from '@/types/vue';
+import { TaskTag } from "@/types/asana";
+import { staticTag } from '@/utils/renderTag';
+import asana from 'asana';
+import { convertAsanaColorToHex } from '@/utils/asana-specific';
+
+export default defineComponent({
+  components: { NSelect, NSpace },
+  props: {
+    field: {
+      type: Object as PropType<asana.resources.CustomField>,
+      required: true
+    },
+    selectedGid: String
+  },
+  setup(props, { emit }) {
+    const selectedEnumGid = ref(props.selectedGid);
+
+    const options = computed(() => {
+      return makeFieldOptions(props.field.enum_options!);
+    });
+
+    watch([selectedEnumGid], () => {
+      emit("update:selectedGid", selectedEnumGid.value);
+    });
+
+    return {
+      selectedEnumGid,
+      options,
+      renderTag: staticTag,
+    }
+  }
+});
+
+// value prop of component only accepts an array of strings, so need array of tagIds
+function makeTagId(tags: TaskTag[] | undefined): string[] {
+  const tagIds = tags?.map((tag) => {
+    return tag.gid;
+  });
+  return tagIds ?? [];
+}
+
+function makeFieldOptions(values: asana.resources.EnumValue[]): TagOption[] {
+  const options = values.map((v) => {
+    const h = convertAsanaColorToHex(v.color);
+    return {
+      label: v.name,
+      value: v.gid,
+      color: h.background,
+      font: h.font
+    } as TagOption
+  });
+  return options;
+}
+</script>

--- a/src/components/TagSelector.vue
+++ b/src/components/TagSelector.vue
@@ -18,7 +18,7 @@ import { TagOption } from '@/types/vue';
 import { Task, TaskTag } from "@/types/asana";
 import { useAsanaStore } from "@/store/asana";
 import { usePrefStore } from "@/store/preferences";
-import { renderTag } from '@/utils/renderTag';
+import { closeableTag } from '@/utils/renderTag';
 
 export default defineComponent({
   components: { NSelect, NSpace },
@@ -49,7 +49,7 @@ export default defineComponent({
     return {
       tagIds,
       options,
-      renderTag,
+      renderTag: closeableTag,
     }
   }
 });

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -16,6 +16,7 @@ import {
 import { Move, Swimlane } from "@/types/layout";
 import { getColumnCount, getPrettyColumnName, convertAsanaColorToHex } from "@/utils/asana-specific";
 import { asanaClient, useAuthStore } from "../auth";
+import { ColumnChange } from "@/utils/custom-fields";
 
 
 export const useAsanaStore = defineStore("asana", {
@@ -235,9 +236,7 @@ export const useAsanaStore = defineStore("asana", {
 
     UPDATE_CUSTOM_FIELDS(taskId: string): void {
       const task = this.tasks.find(task => task.gid === taskId)!;
-      const columnChangeIdx = task?.custom_fields?.findIndex(
-        field => field.name === "column-change"
-      );
+      const columnChangeIdx = task?.custom_fields?.findIndex(field => field.name === ColumnChange);
 
       if (columnChangeIdx === undefined) return;
 
@@ -292,6 +291,7 @@ export const useAsanaStore = defineStore("asana", {
           assignee: taskAndSectionId.task.assignee?.gid ?? null,
           html_notes: taskAndSectionId.task.html_notes,
           due_on: taskAndSectionId.task.due_on,
+          custom_fields: taskAndSectionId.task.custom_fields.reduce((obj, cur) => ({ ...obj, [cur.gid]: cur.enum_value?.gid ?? cur.number_value ?? cur.text_value }), {})
         } as any); // asana interface has incorrect type defintion for assignee - had to typecast to allow null type for assignee field
 
         this.UPDATE_STORIES(taskAndSectionId);

--- a/src/types/asana.ts
+++ b/src/types/asana.ts
@@ -28,12 +28,14 @@ export type User = asana.resources.Users.Type & {
 };
 export type Stories = asana.resources.Stories.Type;
 export type SubTask = { gid: string; resource_type: string; name: string; completed: boolean; };
-export type Task = Omit<asana.resources.Tasks.Type, "tags"> & {
+export type CustomField = asana.resources.CustomField & { text_value: string | null };
+export type Task = Omit<asana.resources.Tasks.Type, "tags" | "custom_fields"> & {
   created_by: { name: string },
   html_notes: string | undefined,
   stories: Stories[],
   subtasks: SubTask[],
   tags: TaskTag[],
+  custom_fields: CustomField[]
 };
 
 export type Assignee = asana.resources.Assignee;

--- a/src/utils/asana-specific.ts
+++ b/src/utils/asana-specific.ts
@@ -30,24 +30,41 @@ function convertAsanaColorToHex(color: string): Hex {
   const black = "#000000";
   const white = "#ffffff";
 
-  const colors = { 
+  const colors = {
     "none": { background: "#C6C4C4", font: black },
-    "dark-red": { background: "#E0726E", font: black }, 
-    "dark-orange": { background: "#DF9077", font: black } , 
-    "light-orange": { background: "#E9BE78", font: black }, 
+    "dark-red": { background: "#E0726E", font: black },
+    "dark-orange": { background: "#DF9077", font: black },
+    "light-orange": { background: "#E9BE78", font: black },
     "dark-brown": { background: "#F5DF82", font: black },
-    "light-green": { background: "#B4CC67", font: black }, 
+    "light-green": { background: "#B4CC67", font: black },
     "dark-green": { background: "#6D9F85", font: white },
     "light-teal": { background: "#71C8C3", font: black },
     "dark-teal": { background: "#ADE5E2", font: black },
-    "light-blue": { background: "#4E74CB", font: white }, 
-    "dark-purple": { background: "#8A86E1", font: white } , 
-    "light-purple": { background: "#A971CE", font: white }, 
+    "light-blue": { background: "#4E74CB", font: white },
+    "dark-purple": { background: "#8A86E1", font: white },
+    "light-purple": { background: "#A971CE", font: white },
     "light-pink": { background: "#EDAEEB", font: black },
-    "dark-pink": { background: "#E278B0 ", font: black }, 
+    "dark-pink": { background: "#E278B0 ", font: black },
     "light-red": { background: "#EE9C9C", font: black },
     "light-warm-gray": { background: "#6D6E6F", font: white },
+    "yellow-green": { background: "#aecf55", font: black },
+    "yellow": { background: "#f8df72", font: black },
+    "cool-gray": { background: "#6d6e6f", font: white },
+    "red": { background: "#f06a6a", font: white },
+    "aqua": { background: "#9ee7e3", font: black },
+    "green": { background: "#5da283", font: white },
+    "yellow-orange": { background: "#f1bd6c", font: black },
+    "orange": { background: "#ec8d71", font: black },
+    "blue": { background: "#4573d2", font: black },
+    "magenta": { background: "#f9aaef", font: black },
+    "purple": { background: "#b36bd4", font: black },
+    "indigo": { background: "#8d84e8", font: black }
   };
+
+  if (!colors[color]) {
+    console.log("Don't know Asana hex colours for", color, ":(")
+    return colors["none"];
+  }
 
   return colors[color];
 }

--- a/src/utils/custom-fields.ts
+++ b/src/utils/custom-fields.ts
@@ -1,0 +1,12 @@
+import { CustomField } from "@/types/asana";
+
+export const ColumnChange = "column-change";
+export const Color = "color";
+
+export function getDisplayableCustomFields(fields: CustomField[]) {
+    return fields.filter(isDisplayableCustomField);
+}
+
+export function isDisplayableCustomField(f: CustomField) {
+    return f.name !== ColumnChange && f.name !== Color && f.enum_options && f.enum_options.length > 0;
+}

--- a/src/utils/renderTag.ts
+++ b/src/utils/renderTag.ts
@@ -2,24 +2,30 @@ import { NTag, SelectRenderTag } from 'naive-ui';
 import { h } from 'vue';
 import { Color } from 'csstype';
 
-export const renderTag: SelectRenderTag = ({ option, handleClose }) => {
-  return h(
-    NTag,
-    {
-      closable: true,
-      round: true,
-      themeOverrides: { 
-        heightMedium: '24px',
-        color: option.color as Color, 
-        border: option.color as Color,
-        textColor: option.font as Color, 
-        closeColor: option.font as Color,
+const renderTag = (closeable: boolean) => {
+  return ({ option, handleClose }) => {
+    return h(
+      NTag,
+      {
+        closable: closeable,
+        round: true,
+        themeOverrides: {
+          heightMedium: '24px',
+          color: option.color as Color,
+          border: option.color as Color,
+          textColor: option.font as Color,
+          closeColor: option.font as Color,
+        },
+        onClose: (e: MouseEvent) => {
+          e.stopPropagation()
+          handleClose()
+        }
       },
-      onClose: (e: MouseEvent) => {
-        e.stopPropagation()
-        handleClose()
-      }
-    },
-    { default: () => option.label }
-  );
+      { default: () => option.label }
+    );
+  }
 }
+
+export const closeableTag: SelectRenderTag = renderTag(true);
+
+export const staticTag: SelectRenderTag = renderTag(false);


### PR DESCRIPTION
We show the custom fields (that have a value and are enums) on the task summary (board)

We then allow editing of custom fields (that are enums).

Note: the asana api doesn't work with clearing a value (they probably have a bad if statement). So currently don't "allow" it

<img width="568" alt="image" src="https://user-images.githubusercontent.com/2255640/165982566-66306ee5-a650-4a8e-b344-e317be838791.png">

<img width="956" alt="image" src="https://user-images.githubusercontent.com/2255640/165982592-a91ddd84-a5c9-4a29-a62b-954d2cfbbea0.png">
