### PR TITLE
Expanded task-width to span entire column

### DIFF
--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="column" :class="classObject" @mouseenter="mouseInside = true" @mouseleave="mouseInside = false">
-    <div class="column-nav" @click="toggleColumn(section?.gid ?? '')">
+  <div class="column" :class="[classObject, singleTaskView ? 'single-task-view' : '']" @mouseenter="mouseInside = true" @mouseleave="mouseInside = false">
+    <div class="column-nav" :class="singleTaskView ? 'single-task-view' : ''" @click="toggleColumn(section?.gid ?? '')">
       <a class="nav-item mouseInside" v-if="!columnCollapsed(section?.gid ?? '')" href="javascript:;"
         @click.prevent.stop="showTaskEditor(section?.gid ?? '')">add task</a>
       <div class="nav-title">{{ columnName ? columnName : "unknown" }}</div>
@@ -15,7 +15,7 @@
     <div v-if="!columnCollapsed(section?.gid ?? '')" @drop="onDrop($event, section?.gid ?? '')"
       @dragenter="onDragEnter($event)" @dragstart="onDragStart()" @dragend="onDragEnd()" @dragover.prevent
       class="droppable" v-bind:id="section?.gid">
-      <task v-for="task in tasks(section?.gid ?? '')" :task="task" :key="task.gid"></task>
+      <task v-for="task in tasks(section?.gid ?? '')" :singleTaskView="singleTaskView" :task="task" :key="task.gid" />
     </div>
   </div>
 </template>
@@ -31,6 +31,7 @@ export default defineComponent({
   components: { Task },
   props: {
     section: Object as PropType<Section>,
+    singleTaskView: Boolean
   },
   setup(props) {
     const asanaStore = useAsanaStore();
@@ -246,7 +247,7 @@ function removeDragOverClass() {
 }
 
 .nav-title {
-  font-size: 1.1rem;
+  font-size: 110%;
   flex-grow: 1;
   padding: 0.3rem 0.2rem;
 }
@@ -274,8 +275,11 @@ function removeDragOverClass() {
   flex-flow: column;
 }
 
+
+
 .droppable {
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .column.collapsed {
@@ -311,5 +315,12 @@ a.nav-item {
 
 a.nav-item.mouseInside {
   opacity: 1;
+}
+
+.column.single-task-view {
+  width: 20vw;
+}
+.column-nav.single-task-view {
+  width: 20vw;
 }
 </style>

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="column" :class="[classObject, singleTaskView ? 'single-task-view' : '']" @mouseenter="mouseInside = true" @mouseleave="mouseInside = false">
-    <div class="column-nav" :class="singleTaskView ? 'single-task-view' : ''" @click="toggleColumn(section?.gid ?? '')">
+    <div class="column-nav" @click="toggleColumn(section?.gid ?? '')">
       <a class="nav-item mouseInside" v-if="!columnCollapsed(section?.gid ?? '')" href="javascript:;"
         @click.prevent.stop="showTaskEditor(section?.gid ?? '')">add task</a>
       <div class="nav-title">{{ columnName ? columnName : "unknown" }}</div>
@@ -15,7 +15,7 @@
     <div v-if="!columnCollapsed(section?.gid ?? '')" @drop="onDrop($event, section?.gid ?? '')"
       @dragenter="onDragEnter($event)" @dragstart="onDragStart()" @dragend="onDragEnd()" @dragover.prevent
       class="droppable" v-bind:id="section?.gid">
-      <task v-for="task in tasks(section?.gid ?? '')" :singleTaskView="singleTaskView" :task="task" :key="task.gid" />
+      <task v-for="task in tasks(section?.gid ?? '')" :task="task" :key="task.gid" />
     </div>
   </div>
 </template>
@@ -275,11 +275,21 @@ function removeDragOverClass() {
   flex-flow: column;
 }
 
-
-
 .droppable {
   flex: 1 1 auto;
+}
+
+.single-task-view .droppable {
+  display: flex;
   width: 100%;
+  max-width: none;
+  flex-direction: column;
+  margin-right: 2px;
+}
+
+.single-task-view .droppable > * {
+  max-width: none;
+  width: 98%;
 }
 
 .column.collapsed {
@@ -318,9 +328,6 @@ a.nav-item.mouseInside {
 }
 
 .column.single-task-view {
-  width: 20vw;
-}
-.column-nav.single-task-view {
-  width: 20vw;
+  min-width: 20vw;
 }
 </style>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -2,7 +2,6 @@
   <div
     v-bind:id="task.gid"
     class="task"
-    :class="singleTaskView ? 'single-task-view' : ''"
     draggable="true"
     :style="{ opacity: opacity, ...backgroundAndTextColor }"
     @dragstart="startDrag($event, task)"
@@ -70,7 +69,6 @@ export default defineComponent({
       type: Object as PropType<Task>,
       required: true,
     },
-    singleTaskView: Boolean,
   },
   components: {
     NIcon,
@@ -208,10 +206,6 @@ hr {
   overflow: auto;
 }
 
-.task.single-task-view {
-  width: 97%;
-  max-width: none;
-}
 
 .task .subtask-icon {
   margin-left: auto;

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -2,6 +2,7 @@
   <div
     v-bind:id="task.gid"
     class="task"
+    :class="singleTaskView ? 'single-task-view' : ''"
     draggable="true"
     :style="{ opacity: opacity, ...backgroundAndTextColor }"
     @dragstart="startDrag($event, task)"
@@ -69,6 +70,7 @@ export default defineComponent({
       type: Object as PropType<Task>,
       required: true,
     },
+    singleTaskView: Boolean,
   },
   components: {
     NIcon,
@@ -197,13 +199,18 @@ hr {
   margin-bottom: 4px;
   background-color: white;
   margin-right: 2px;
-  width: 97%;
+  width: 48%;
   max-width: 15rem;
   min-height: 2.5rem;
   cursor: move;
   display: inline-block;
   vertical-align: top;
   overflow: auto;
+}
+
+.task.single-task-view {
+  width: 97%;
+  max-width: none;
 }
 
 .task .subtask-icon {

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -168,7 +168,7 @@ hr {
   margin-bottom: 4px;
   background-color: white;
   margin-right: 2px;
-  width: 48%;
+  width: 97%;
   max-width: 15rem;
   min-height: 2.5rem;
   cursor: move;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,7 @@
           v-for="section in sections(swimlane.name)"
           :section="section"
           :key="section.gid"
+          :singleTaskView="sections(swimlane.name).length > 5"
         />
       </swimlane>
     </div>


### PR DESCRIPTION
Created a single task view applied on >5 columns.
- Created a new styling class: single-task-view.
- Dynamically assign single-task-view if >5 columns in swimlane.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/40780156/167486222-733da005-697f-469a-a024-ef53f992d92a.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/40780156/167486300-5cfe8dc9-dbdf-4e3f-b739-0bfa8a0478dc.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202237343489023