### PR TITLE
Show custom fields on create

### DIFF
--- a/src/components/TaskEditor.vue
+++ b/src/components/TaskEditor.vue
@@ -253,19 +253,13 @@ export default defineComponent({
           if (task.gid) {
             const taskCustomField = taskEditorSectionIdAndTask.task.custom_fields?.find(cf => cf.gid === field.gid);
             if (taskCustomField) taskCustomField.enum_value = selectedVal;
-          } else if (task.custom_fields) {
-            task.custom_fields.push({
-              ...field,
-              enum_value: selectedVal,
-            })
           } else {
-            task.custom_fields = [];
+            task.custom_fields = task.custom_fields ?? [];
             task.custom_fields.push({
               ...field,
               enum_value: selectedVal,
             })
-          }
-
+          } 
         }
       });
 

--- a/src/components/TaskEditor.vue
+++ b/src/components/TaskEditor.vue
@@ -39,7 +39,7 @@
         <TagSelector :task="taskEditorSectionIdAndTask.task" />
       </div>
       <template
-        v-for="(field, index) in taskEditorSectionIdAndTask.task.custom_fields"
+        v-for="(field, index) in project?.custom_fields"
         :key="field.name"
       >
         <div class="field" v-if="isDisplayableCustomField(field)">
@@ -188,6 +188,7 @@ export default defineComponent({
     const htmlNotes = ref<string>();
     const customFieldSelectedGids = ref<(string | undefined)[]>([]);
     const projectId = computed(() => asanaStore.selectedProject);
+    const project = computed(() => asanaStore.projects.find((proj) => proj.gid === asanaStore.selectedProject))
 
     const taskEditorSectionIdAndTask = computed(() => {
       return prefStore.taskEditorSectionIdAndTask!;
@@ -292,6 +293,7 @@ export default defineComponent({
     return {
       taskEditorSectionIdAndTask,
       projectId,
+      project,
       dueDate,
       taskName,
       assigneeGid,

--- a/src/components/TaskEditor.vue
+++ b/src/components/TaskEditor.vue
@@ -242,14 +242,30 @@ export default defineComponent({
       }
 
       task.html_notes = htmlNotes.value;
-      task.custom_fields?.forEach((el, idx) => {
+      project.value?.custom_fields?.forEach((el, idx) => {
         const field = el;
         if (isDisplayableCustomField(field)) {
           const selectedVal =
             field.enum_options?.find(
               (o) => o.gid === customFieldSelectedGids.value[idx]
             ) ?? null;
-          field.enum_value = selectedVal;
+         
+          if (task.gid) {
+            const taskCustomField = taskEditorSectionIdAndTask.task.custom_fields?.find(cf => cf.gid === field.gid);
+            if (taskCustomField) taskCustomField.enum_value = selectedVal;
+          } else if (task.custom_fields) {
+            task.custom_fields.push({
+              ...field,
+              enum_value: selectedVal,
+            })
+          } else {
+            task.custom_fields = [];
+            task.custom_fields.push({
+              ...field,
+              enum_value: selectedVal,
+            })
+          }
+
         }
       });
 

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -21,7 +21,7 @@ import {
   convertAsanaColorToHex,
 } from "@/utils/asana-specific";
 import { asanaClient, useAuthStore } from "../auth";
-import { ColumnChange } from "@/utils/custom-fields";
+import { ColumnChange, isDisplayableCustomField } from "@/utils/custom-fields";
 import { isFilenameExtensionImage } from "@/utils/match";
 
 export const useAsanaStore = defineStore("asana", {
@@ -268,6 +268,14 @@ export const useAsanaStore = defineStore("asana", {
           ...taskAndSectionId.task,
           tags: taskAndSectionId.newTags,
           projects: [this.selectedProject],
+          custom_fields: taskAndSectionId.task.custom_fields?.reduce(
+            (obj, cur) => ({
+              ...obj,
+              [cur.gid]:
+                cur.enum_value?.gid ?? cur.number_value ?? cur.text_value,
+            }),
+            {}
+          ),
           memberships: [
             {
               section: taskAndSectionId.sectionId,
@@ -275,6 +283,7 @@ export const useAsanaStore = defineStore("asana", {
             },
           ],
         } as any)) as Task;
+
         task.created_by = { name: useAuthStore().user?.name ?? "" };
         this.tasks.push(task);
         this.UPDATE_CUSTOM_FIELDS(task.gid);

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -454,7 +454,7 @@ export const useAsanaStore = defineStore("asana", {
               limit: 100,
               workspace: workspace.gid,
               archived: false,
-              opt_fields: "custom_field_settings, custom_field_settings.custom_field.name"
+              opt_fields: "name, custom_field_settings.custom_field.name, custom_field_settings.custom_field.enum_options"
             };
             let projectResponse: any = await asanaClient?.projects.findAll(
               options
@@ -467,18 +467,17 @@ export const useAsanaStore = defineStore("asana", {
               const projects = projectResponse.data.map((p) => {
                 return {
                   ...p,
-                  custom_field_settings: undefined, // we only care about the custom fields
                   custom_fields: p.custom_field_settings.map((el) => {
                     return { 
                       name: el.custom_field.name, 
-                      gid: el.custom_field.gid
+                      gid: el.custom_field.gid,
+                      enum_options: el.custom_field.enum_options, 
                     }
                   }),
                   workspaceGid: workspace.gid
                 } as Project
               });
               this.ADD_PROJECTS(projects);
-              console.log(projects);
             }
           });
         }

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -269,11 +269,22 @@ export const useAsanaStore = defineStore("asana", {
           tags: taskAndSectionId.newTags,
           projects: [this.selectedProject],
           custom_fields: taskAndSectionId.task.custom_fields?.reduce(
-            (obj, cur) => ({
-              ...obj,
-              [cur.gid]:
-                cur.enum_value?.gid ?? cur.number_value ?? cur.text_value,
-            }),
+            (obj, cur) => {
+              if (cur.name == ColumnChange) {
+                return {
+                  ...obj,
+                  [cur.gid]: new Date().toISOString()
+                }
+              }
+              if (!isDisplayableCustomField) {
+                return obj;
+              }
+              return  {
+                ...obj,
+                [cur.gid]:
+                  cur.enum_value?.gid ?? cur.number_value ?? cur.text_value,
+              }
+            },
             {}
           ),
           memberships: [
@@ -286,7 +297,6 @@ export const useAsanaStore = defineStore("asana", {
 
         task.created_by = { name: useAuthStore().user?.name ?? "" };
         this.tasks.push(task);
-        this.UPDATE_CUSTOM_FIELDS(task.gid);
       };
 
       this.ADD_ACTION("creating task", createTask);

--- a/src/store/asana/index.ts
+++ b/src/store/asana/index.ts
@@ -413,16 +413,25 @@ export const useAsanaStore = defineStore("asana", {
               limit: 100,
               workspace: workspace.gid,
               archived: false,
+              opt_fields: "custom_field_settings, custom_field_settings.custom_field.name"
             };
             let projectResponse: any = await asanaClient?.projects.findAll(options);
             for (; projectResponse; projectResponse = await projectResponse.nextPage()) {
               const projects = projectResponse.data.map(p => {
                 return {
                   ...p,
+                  custom_field_settings: undefined, // we only care about the custom fields
+                  custom_fields: p.custom_field_settings.map((el) => {
+                    return { 
+                      name: el.custom_field.name, 
+                      gid: el.custom_field.gid
+                    }
+                  }),
                   workspaceGid: workspace.gid
                 } as Project
               });
               this.ADD_PROJECTS(projects);
+              console.log(projects);
             }
           });
         }

--- a/src/types/asana.ts
+++ b/src/types/asana.ts
@@ -7,6 +7,7 @@ export type BaseResource = Omit<Resource, "resource_subtype" | "id">;
 // interface doesn't have ProjectCompact type https://developers.asana.com/docs/project-compact
 export type Project = BaseResource & {
   workspaceGid: string,
+  custom_fields: CustomField[] | null | undefined
 };
 export type QueriedTask = BaseResource & {
   completed: boolean,


### PR DESCRIPTION
- Added a custom_fields property in the Project type.
- In TaskEditor.vue, custom fields are created based on data contained in the Project type instead of Task type. This is to enable showing available custom fields on the UI when creating a new task.
- Send custom_fields information when creating a new task.